### PR TITLE
RHEL based OS service name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,8 +50,7 @@ class ldap::params {
     /(?i-mx:debian|ubuntu|suse|opensuse)/ => '/var/run/slapd',
   }
   $lp_openldap_service = $operatingsystem ? {
-    /(?i-mx:fedora|rhel|centos|suse|opensuse)/ => 'ldap',
-    /(?i-mx:debian|ubuntu)/                    => 'slapd',
+    default => 'slapd',
   }
   $lp_openldap_conf_dir = $operatingsystem ? {
     /(?i-mx:fedora|rhel|centos|suse|opensuse)/ => '/etc/openldap',


### PR DESCRIPTION
Should also be slapd on eg centos, changed it to a default setting.
