### PR TITLE
Support for Ubuntu 12.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,6 +47,9 @@ class ldap::params {
                                'libdb4.2',
                                ]
         }
+	precise: {
+          $openldap_packages = ['slapd', 'ldap-utils', 'libperl5.14']
+	}
         default: {
           $openldap_packages = ['slapd', 'ldap-utils', 'libperl5.10']
         }


### PR DESCRIPTION
Hi,

Ubuntu 12.04 comes with libperl5.14 instead of 5.10. I've added this check to the params.pp file.

Cheers,

Jurgen
