### PR TITLE
Fix: syntax error in manifests/params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,10 +91,11 @@ class ldap::params {
       }
     } 'RedHat': {
       case $::operatingsystemrelease {
-      /^5\./: {
-        $lp_openldap_service = 'ldap'
-      } /^6\./: {
-        $lp_openldap_service = 'slapd'
+        /^5\./: {
+          $lp_openldap_service = 'ldap'
+        } /^6\./: {
+          $lp_openldap_service = 'slapd'
+        }
       }
       $openldap_packages = [
         'openldap', 'openldap-servers', 'openldap-clients'


### PR DESCRIPTION
Added missing curly brace to fix "Syntax error at '='; expected '}' at /[...]/modules/ldap/manifests/params.pp:99" error.
