### PR TITLE
Fix #12: Avoid duplicate package errors by virtualising them

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -18,9 +18,7 @@ class ldap::client(
   $ssl = false
 ) {
 
-  class { 'ldap::client::package':
-    ensure => $ensure,
-  }
+  include ldap::client::package
   class { 'ldap::client::base':
     ensure    => $ensure,
     ssl       => $ssl,

--- a/manifests/client/package.pp
+++ b/manifests/client/package.pp
@@ -14,12 +14,8 @@
 # Sample Usage:
 #
 # This class file is not called directly
-class ldap::client::package(
-  $ensure='present'
-) {
+class ldap::client::package {
   include ldap::params
 
-  package { $ldap::params::openldap_client_packages:
-    ensure => $ensure,
-  }
+  realize Package[$ldap::params::openldap_client_packages]
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -115,4 +115,11 @@ class ldap::params {
       fail("${module_name} unsupported for ${::operatingsystem}.")
     }
   }
+
+  # Virtual package resources so we avoid duplicates when defining the
+  # client and server on the same machine
+  $openldap_combined_packages = unique(flatten([$openldap_packages, $openldap_client_packages]))
+  @package { $openldap_combined_packages:
+    ensure => 'present',
+  }
 }

--- a/manifests/server/package.pp
+++ b/manifests/server/package.pp
@@ -34,9 +34,7 @@ class ldap::server::package(
     before => Package[$ldap::params::openldap_packages],
   }
 
-  package { $ldap::params::openldap_packages:
-    ensure => present,
-  }
+  realize Package[$ldap::params::openldap_packages]
 
   ## This section modifies the /etc/default file to allow for
   ## slapd.conf configuration as opposed to the cn=config


### PR DESCRIPTION
If you set up both the server and client on the same RedHat machine,
you get a duplicate package error as they both depend on 'openldap'.
Making the package definitions for these virtual and then realizing
them immediately afterwards, we avoid that issue.

Note: fixes the 'ensure' value of the packages, but since this doesn't
seem to be available for a user to customise I'm not really sure why
it's there at the moment.
